### PR TITLE
fix: types

### DIFF
--- a/packages/reactotron-react-query/package.json
+++ b/packages/reactotron-react-query/package.json
@@ -3,7 +3,7 @@
     "version": "2.0.1",
     "description": "Reactotron plugin for React Query",
     "main": "dist/src/index.js",
-    "types": "dist/types/index.d.ts",
+    "types": "dist/types/src/index.d.ts",
     "repository": "https://github.com/hsndmr/reactotron-react-query",
     "license": "MIT",
     "author": "demirjs",

--- a/packages/reactotron-react-query/package.json
+++ b/packages/reactotron-react-query/package.json
@@ -24,7 +24,7 @@
     "exports": {
       ".": {
         "import": "./dist/src/index.js",
-        "types": "./dist/types/index.d.ts"
+        "types": "./dist/types/src/index.d.ts"
       }
     },
     "files": [
@@ -33,4 +33,3 @@
       "README.md"
     ]
   }
-  


### PR DESCRIPTION
The package.json is pointing to the wrong directory for the types